### PR TITLE
softFail config added to set component to degraded on error

### DIFF
--- a/src/main/scala/com/webtrends/harness/component/kafka/actor/KafkaWriter.scala
+++ b/src/main/scala/com/webtrends/harness/component/kafka/actor/KafkaWriter.scala
@@ -93,7 +93,7 @@ class KafkaWriter(val healthParent: ActorRef) extends Actor
     } recover {
       case ex: Exception =>
         log.error(s"Unable To write Event, ackId=[$ackId]", ex)
-        setHealth(HealthComponent(self.path.name, ComponentState.CRITICAL, "Last message failed to send"))
+        setHealth(HealthComponent(self.path.name, errorState, "Last message failed to send"))
         Right(SendFailureException(ackId, ex))
     } get
   }

--- a/src/main/scala/com/webtrends/harness/component/kafka/health/KafkaWriterHealthCheck.scala
+++ b/src/main/scala/com/webtrends/harness/component/kafka/health/KafkaWriterHealthCheck.scala
@@ -71,7 +71,7 @@ trait KafkaWriterHealthCheck { this: KafkaWriter =>
   //
   // Addressing this by wrapping the returned java Future and into a scala Future and blocking with defined timeout.
   // If it completes successfully, and we don't have a normal health, set it to NORMAL
-  // If it throws an exception or times out, set our health to CRITICAL
+  // If it throws an exception or times out, set our health to alert error
   //
   // To limit performance impact, we are only monitoring a single send at at ime
   def monitorSendHealth(sendFuture: java.util.concurrent.Future[RecordMetadata]) {
@@ -88,7 +88,7 @@ trait KafkaWriterHealthCheck { this: KafkaWriter =>
             catch {
               case ex: Exception =>
                 log.error("Unable to produce data. Marking producer as unhealthy", ex)
-                setHealth(HealthComponent(self.path.name, ComponentState.CRITICAL, ex.getMessage))
+                setHealth(HealthComponent(self.path.name, errorState, ex.getMessage))
             }
             inProcessSend = None // Note that this may be executed in a different thread than the current message being processed
           }


### PR DESCRIPTION
Wookiee health forces consuming applications into critical state when any subcomponent goes critical. Added option to allow for a soft fail into degraded mode instead of critical if your application doesn't critically depend on wookiee-kafka.