### PR TITLE
throws failures that are being watched for

### DIFF
--- a/src/main/scala/com/webtrends/harness/component/kafka/health/KafkaWriterHealthCheck.scala
+++ b/src/main/scala/com/webtrends/harness/component/kafka/health/KafkaWriterHealthCheck.scala
@@ -89,8 +89,11 @@ trait KafkaWriterHealthCheck { this: KafkaWriter =>
               case ex: Exception =>
                 log.error("Unable to produce data. Marking producer as unhealthy", ex)
                 setHealth(HealthComponent(self.path.name, errorState, ex.getMessage))
+                throw ex
             }
-            inProcessSend = None // Note that this may be executed in a different thread than the current message being processed
+            finally {
+              inProcessSend = None // Note that this may be executed in a different thread than the current message being processed
+            }
           }
         }(scala.concurrent.ExecutionContext.Implicits.global)
     }


### PR DESCRIPTION
Only consumer of the monitorSendHealth method was already wrapping the result in a Try block and relied on write failures bubbling up to appropriately send a failure exception to wookiee-kafka's consumer when asking with a MessagesWithAck request. No longer swallowing this exception so that the failure exceptions can be sent.